### PR TITLE
Translation hotfix

### DIFF
--- a/monri.php
+++ b/monri.php
@@ -22,7 +22,7 @@ class Monri extends PaymentModule
     protected $_html = '';
     protected $_postErrors = array();
 
-    private $paymentLabelText = 'Pay using Monri - Kartično plaćanje';
+    private $paymentLabelText;
 
     public $details;
     public $owner;
@@ -50,6 +50,7 @@ class Monri extends PaymentModule
         $this->displayName = $this->l('Monri');
         $this->description = $this->l('Accept all payments offered by Monri');
         $this->confirmUninstall = $this->l('Are you sure you want to uninstall?');
+        $this->paymentLabelText = $this->l('Pay using Monri - Kartično plaćanje');
 
         if (!count(Currency::checkPaymentCurrencies($this->id))) {
             $this->warning = $this->l('No currency has been set for this module.');
@@ -111,7 +112,7 @@ class Monri extends PaymentModule
             'monri_path' => $this->_path,
             'action' => $action,
             'monri_inputs' => $monri_inputs,
-            'payment_text' => $this->l($this->paymentLabelText),
+            'payment_text' => $this->paymentLabelText,
         ));
 
         return $this->display( __FILE__, 'views/templates/hook/payment.tpl' );
@@ -416,7 +417,7 @@ class Monri extends PaymentModule
         ];
 
         // Correct test?
-        $externalOption->setCallToActionText($this->l($this->paymentLabelText))
+        $externalOption->setCallToActionText($this->paymentLabelText)
             ->setAction($form_url)
             ->setInputs($new_inputs);
 


### PR DESCRIPTION
Placed `paymentLabelText` inside the `__construct`.